### PR TITLE
fixed rate_func not working in MoveAlongPath

### DIFF
--- a/manimlib/animation/movement.py
+++ b/manimlib/animation/movement.py
@@ -113,5 +113,5 @@ class MoveAlongPath(Animation):
         super().__init__(mobject, suspend_mobject_updating=suspend_mobject_updating, **kwargs)
 
     def interpolate_mobject(self, alpha: float) -> None:
-        point = self.path.point_from_proportion(alpha)
+        point = self.path.point_from_proportion(self.rate_func(alpha))
         self.mobject.move_to(point)


### PR DESCRIPTION
## Code for Test

```py
from manimlib import *

class TestCase(Scene):
    def construct(s):
        t1 = Text("1")
        t2 = Text("1")
        start = 4 * LEFT
        end = 4 * RIGHT
        t1.move_to(start)
        t2.move_to(start)
        path1 = ArcBetweenPoints(start, end)
        path2 = Line(start, end)
        s.add(t1)
        s.add(t2)
        s.wait(1)
        s.play(MoveAlongPath(t1, path1), rate_func = double_smooth)
        s.play(MoveAlongPath(t2, path2), rate_func = double_smooth)
```